### PR TITLE
API Explorer does not work when there are arguments on path.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,3 +33,4 @@ Current or previous core committers:
 Contributors:
 
 * Piotr Skamruk (jellonek) 2018-08-08
+* Daniel Debonzi (debonzi) 2019-10-21

--- a/pyramid_apispec/views.py
+++ b/pyramid_apispec/views.py
@@ -84,5 +84,5 @@ def swagger_ui_script_template(request, spec_route_name, **kwargs):
         "pyramid_apispec", "static/index_script_template.html"
     ).decode("utf8")
     return Template(template).safe_substitute(
-        swagger_spec_url=request.route_url(spec_route_name)
+        swagger_spec_url=request.route_url(spec_route_name, **request.matchdict)
     )


### PR DESCRIPTION
Without the fix, the test code
```python
    def test_explorer_with_path_arg(self, spec):
        def spec_view(request):
            return spec.to_dict()

        with Configurator() as config:
            config.add_route("openapi_spec", "/api/{version}/openapi.json")
            config.add_view(spec_view, route_name="openapi_spec", renderer='json')

            config.include("pyramid_apispec.views")
            config.pyramid_apispec_add_explorer(
                spec_route_name="openapi_spec",
                explorer_route_path='/api/{version}/api-explorer'
            )
            app = config.make_wsgi_app()

            testapp = WebTestApp(app)
            testapp.get('/api/v1/openapi.json')
            testapp.get('/api/v1/api-explorer')
```
will result in error:
```
pyramid_apispec/views.py:87: in swagger_ui_script_template
    swagger_spec_url=request.route_url(spec_route_name)
../../.pyenv/versions/3.7.2/envs/papispec/lib/python3.7/site-packages/pyramid/url.py:261: in route_url
    path = route.generate(kw)  # raises KeyError if generate fails
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dict = {}

    def generator(dict):
        newdict = {}
        for k, v in dict.items():
            if PY2:
                if v.__class__ is text_type:
                    # url_quote below needs bytes, not unicode on Py2
                    v = v.encode('utf-8')
            else:
                if v.__class__ is binary_type:
                    # url_quote below needs a native string, not bytes on Py3
                    v = v.decode('utf-8')
    
            if k == remainder:
                # a stararg argument
                if is_nonstr_iter(v):
                    v = '/'.join([q(x) for x in v])  # native
                else:
                    if v.__class__ not in string_types:
                        v = str(v)
                    v = q(v)
            else:
                if v.__class__ not in string_types:
                    v = str(v)
                # v may be bytes (py2) or native string (py3)
                v = q(v)
    
            # at this point, the value will be a native string
            newdict[k] = v
    
>       result = gen % newdict  # native string result
E       KeyError: 'version'

../../.pyenv/versions/3.7.2/envs/papispec/lib/python3.7/site-packages/pyramid/urldispatch.py:256: KeyError
```