### PR TITLE
Update README example and the demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,62 +18,106 @@ Check out the demo folder and minimal application example by running:
 
 You can then visit your API explorer page at http://0.0.0.0:6543/api-explorer.
 
-# Examples
+Or visit [generated documentation here](https://ergo.github.io/pyramid_apispec/gh-pages)
+for an example of the demo site.
+(please note that actual REST API is not working in GitHub pages)
 
-Visit [generated documentation here](https://ergo.github.io/pyramid_apispec/gh-pages)
-(please note that actual REST API is not working in github pages)
+**Note:** The demo site is using OpenAPI/Swagger v2.0.
+OpenAPI 3.0 is supported as well, it just uses a different YAML schema so pay attention to examples online.
+
+# Example
+
+This example is based on [apispec](https://apispec.readthedocs.io/en/latest/#example-application),
+adapted for Pyramid and `pyramid_apispec` (updated as of `apispec` v5.1.0).
+
+*This example is using OpenAPI 3.0.2*
 
 ## Hinting a route and its view:
 
-    @view_config(route_name='foo_route', renderer='json')
-    def foo_view():
-        """A greeting endpoint.
+Add the OpenAPI YAML to the view docstring.
+Optionally use Marshmallow schemas to define the inputs and outputs.
 
-        ---
-        x-extension: value
-        get:
-            description: some description
-            responses:
-                200:
-                    description: response for 200 code
-                    schema:
-                        $ref: #/definitions/BarBodySchema
-        """
-        return 'hi'
+```python
+import uuid
+
+from marshmallow import Schema, fields
+from pyramid.view import view_config
+
+# Optional marshmallow support
+class CategorySchema(Schema):
+    id = fields.Int()
+    name = fields.Str(required=True)
+    
+class PetSchema(Schema):
+    categories = fields.List(fields.Nested(CategorySchema))
+    name = fields.Str()
+
+@view_config(route_name="random_pet", renderer="json")
+def random_pet(request):
+    """A cute furry animal endpoint.
+    ---
+    get:
+      description: Get a random pet
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: Return a pet
+          content:
+            application/json:
+              schema: PetSchema
+    """
+    # Hardcoded example data
+    pet_data = {
+        "name": "sample_pet_" + str(uuid.uuid1()),
+        "categories": [{"id": 1, "name": "sample_category"}],
+    }
+    return PetSchema().dump(pet_data)
+```
+
+For more details on how to document the API, see the [OpenAPI specification](https://swagger.io/specification/).
 
 ## Rendering the spec as JSON response:
 
-    from apispec import APISpec
-    from apispec.ext.marshmallow import MarshmallowPlugin
-    from pyramid_apispec.helpers import add_pyramid_paths
+```python
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from pyramid.view import view_config
+from pyramid_apispec.helpers import add_pyramid_paths
 
-    @view_config(route_name='openapi_spec', renderer='json')
-    def api_spec(request):
-        spec = APISpec(
-            title='Some API',
-            version='1.0.0',
-            plugins=[MarshmallowPlugin()],
-        )
-        # using marshmallow plugin here
-        spec.definition('SomeFooBody', schema=MarshmallowSomeFooBodySchema)
+@view_config(route_name="openapi_spec", renderer="json")
+def api_spec(request):
+    """View to generate the OpenAPI JSON output."""
+    spec = APISpec(
+        title="Some API",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        plugins=[MarshmallowPlugin()],
+    )
 
-        # inspect the `foo_route` and generate operations from docstring
-        add_pyramid_paths(spec, 'foo_route', request=request)
+    # Optional security scheme support
+    api_key_scheme = {"type": "apiKey", "in": "header", "name": "X-API-Key"}
+    spec.components.security_scheme("ApiKeyAuth", api_key_scheme)
+    
+    # Optionally register Marshmallow schema for more flexibility
+    spec.components.schema("Pet", schema=PetSchema)
+    
+    # inspect the `random_pet` route and generate operations from docstring
+    add_pyramid_paths(spec, 'random_pet', request=request)
 
-        # inspection supports filtering via pyramid add_view predicate arguments
-        add_pyramid_paths(
-            spec, 'bar_route', request=request, request_method='post')
-        return spec.to_dict()
+    return spec.to_dict()
+```
 
-# Adding the API explorer view
+## Adding the API Explorer View
 
 To complement the specification file generation, this package can also provide an API explorer
 for your application's API via the Swagger UI project:
 
-    config.include('pyramid_apispec.views')
-    config.add_route("openapi_spec", "/openapi.json")
-    config.pyramid_apispec_add_explorer(
-        spec_route_name='openapi_spec')
+```python
+config.include("pyramid_apispec.views")
+config.add_route("openapi_spec", "/openapi.json")
+config.pyramid_apispec_add_explorer(spec_route_name="openapi_spec")
+```
 
 By default you need to pass the route name of the view that serves the OpenAPI
 specification in your application. If needed you can specify a Pyramid `permission` or

--- a/demo/app.py
+++ b/demo/app.py
@@ -33,13 +33,11 @@ def users_post(request):
         name: "body"
         description: "Foo bar"
         required: true
-        schema:
-          $ref: "#/definitions/FooBodySchema"
+        schema: FooBodySchema
       responses:
           200:
               description: response for 200 code
-              schema:
-                $ref: "#/definitions/FooBodySchema"
+              schema: FooBodySchema
     """
     schema = validation.FooBodySchema()
     struct = schema.loads(request.body or "{}")
@@ -56,14 +54,12 @@ def bar_get(request):
         parameters:
           - in: query
             name: offset
-            schema:
-              type: integer
+            type: integer
             description: The number of items to skip
         responses:
             200:
                 description: response for 200 code
-                schema:
-                  $ref: "#/definitions/BarBodySchema"
+                schema: BarBodySchema
     """
     return {"a_field": random.random(), "b_field": random.randint(1, 999999)}
 
@@ -88,13 +84,11 @@ def bar_post(request):
         name: "body"
         description: "Bar body description"
         required: true
-        schema:
-          $ref: "#/definitions/BarBodySchema"
+        schema: BarBodySchema
       responses:
           200:
               description: response for 200 code
-              schema:
-                $ref: "#/definitions/BarBodySchema"
+              schema: BarBodySchema
     """
     schema = validation.BarBodySchema(many=True)
     struct = schema.loads(request.body or "{}")
@@ -109,12 +103,16 @@ def api_spec(request):
     spec = APISpec(
         title="Some API",
         version="1.0.0",
-        openapi_version="2.0.0",
+        openapi_version="2.0",
         plugins=[MarshmallowPlugin()],
     )
     # using marshmallow plugin here
     spec.components.schema("FooBodySchema", schema=validation.FooBodySchema)
     spec.components.schema("BarBodySchema", schema=validation.BarBodySchema(many=True))
+
+    # register API security scheme
+    api_auth_scheme = {"type": "apiKey", "in": "header", "name": "Authorization"}
+    spec.components.security_scheme("APIKeyHeader", api_auth_scheme)
 
     # inspect the `foo_route` and generate operations from docstring
     add_pyramid_paths(spec, "users", request=request)

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.17.1/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.35.2/swagger-ui.css" >
   <style>
     html
     {
@@ -65,8 +65,8 @@
 
 <div id="swagger-ui"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.17.1/swagger-ui-bundle.js"> </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.17.1/swagger-ui-standalone-preset.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.35.2/swagger-ui-bundle.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.35.2/swagger-ui-standalone-preset.js"> </script>
 <script>
     window.onload = function() {
 

--- a/gh-pages/openapi.json
+++ b/gh-pages/openapi.json
@@ -23,12 +23,12 @@
                 "parameters": [
                     {
                         "in": "body",
-                        "name": "body",
-                        "description": "Foo bar",
                         "required": true,
+                        "name": "body",
                         "schema": {
                             "$ref": "#/definitions/FooBodySchema"
-                        }
+                        },
+                        "description": "Foo bar"
                     }
                 ],
                 "responses": {
@@ -48,9 +48,7 @@
                     {
                         "in": "query",
                         "name": "offset",
-                        "schema": {
-                            "type": "integer"
-                        },
+                        "type": "integer",
                         "description": "The number of items to skip"
                     }
                 ],
@@ -79,12 +77,12 @@
                 "parameters": [
                     {
                         "in": "body",
-                        "name": "body",
-                        "description": "Bar body description",
                         "required": true,
+                        "name": "body",
                         "schema": {
                             "$ref": "#/definitions/BarBodySchema"
-                        }
+                        },
+                        "description": "Bar body description"
                     }
                 ],
                 "responses": {
@@ -98,14 +96,11 @@
             }
         }
     },
-    "tags": [],
     "info": {
         "title": "Some API",
         "version": "1.0.0"
     },
-    "swagger": "2.0.0",
-    "parameters": {},
-    "responses": {},
+    "swagger": "2.0",
     "definitions": {
         "FooBodySchema": {
             "type": "object",
@@ -133,26 +128,30 @@
             ]
         },
         "BarBodySchema": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "a_field": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 512
-                    },
-                    "b_field": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 512
-                    }
+            "type": "object",
+            "properties": {
+                "a_field": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 512
                 },
-                "required": [
-                    "a_field",
-                    "b_field"
-                ]
-            }
+                "b_field": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 512
+                }
+            },
+            "required": [
+                "a_field",
+                "b_field"
+            ]
+        }
+    },
+    "securityDefinitions": {
+        "APIKeyHeader": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "Authorization"
         }
     }
 }

--- a/pyramid_apispec/helpers.py
+++ b/pyramid_apispec/helpers.py
@@ -17,8 +17,7 @@ Inspecting a route and its view::
             responses:
                 200:
                     description: a pet to be returned
-                    schema:
-                        $ref: #/definitions/SomeFooBody
+                    schema: SomeFooBody
         \"""
         return 'hi'
 
@@ -27,9 +26,8 @@ Inspecting a route and its view::
         spec = APISpec(
             title='Some API',
             version='1.0.0',
-            plugins=[
-                'apispec.ext.marshmallow'
-            ],
+            openapi_version='2.0',
+            plugins=[MarshmallowPlugin()],
         )
         # using marshmallow plugin here
         spec.definition('SomeFooBody', schema=MarshmallowSomeFooBodySchema)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     setup_requires=["pytest-runner"],
     extras_require={
         "dev": ["coverage", "pytest", "tox", "webtest", "wheel", "twine"],
-        "demo": ["marshmallow==3.8.0", "apispec", "webtest"],
+        "demo": ["marshmallow>=3.13.0,<4.0.0", "apispec>=5.1.0,<6.0.0"],
         "lint": ["black"],
     },
 )


### PR DESCRIPTION
Updated the README to reflect some changes in `apispec` because when I first tried to set this up a while back I ran into issues.  (Since it can be a moving target I did not the version at the time of this documentation in case that helps others.)

Updated the demo app because when I pasted the resulting `openapi.json` into https://editor.swagger.io I got the following errors:
```
Semantic error at paths./users.post.security.0
Security requirements must match a security definition
Jump to line 6

Structural error at paths./bar.get.parameters.0
should NOT have additional properties
additionalProperty: schema
Jump to line 32

Structural error at paths./bar.get.parameters.0
should have required property 'type'
missingProperty: type
Jump to line 32

Structural error at swagger
should be equal to one of the allowed values
allowedValues: 2.0
Jump to line 67
```

Fixes #16